### PR TITLE
decode query params

### DIFF
--- a/packages/helpers/packages/HttpHelpers/index.js
+++ b/packages/helpers/packages/HttpHelpers/index.js
@@ -84,7 +84,7 @@ export const universalCall = async ({
   let callUrl = url;
   if (Object.keys(params).length > 0) {
     const queryParameters = serializeObject(params);
-    callUrl += `?${queryParameters}`;
+    callUrl += `?${decodeURIComponent(queryParameters)}`;
   }
 
   /**


### PR DESCRIPTION
to avoid double encoding for query params that are already encoded,
query params should be decoded first and the concat with call url