### PR TITLE
fixed image component

### DIFF
--- a/packages/ui/packages/Image/src/index.js
+++ b/packages/ui/packages/Image/src/index.js
@@ -10,19 +10,15 @@ import { LogoAnimation } from '../../Loading/src';
  * @returns {*}
  * @constructor
  */
-const Image = props => {
-  const { src, size, ...rest } = props;
-  let { loader, error } = props;
-
-  if(!loader) {
-    loader = <LogoAnimation size={size} />;
-  }
-  if(!error) {
-    error = <LogoAnimation size={size} />;
-  }
-
-  return <Img data-testid="image" src={src} loader={loader} unloader={error} {...rest} />;
-};
+const Image = ({src, size, loader, error, ...rest}) => (
+  <Img
+    data-testid="image"
+    src={src}
+    loader={loader || <LogoAnimation size={size} />}
+    unloader={error || <LogoAnimation size={size} />}
+    {...rest}
+  />
+);
 
 Image.propTypes = {
   src: PropTypes.string.isRequired,


### PR DESCRIPTION
since we spread the rest properties of the props with `...rest` in props de-structure, every prop but the src and size would be omitted from the props variable and they are able to de-structure from the `rest` not the `props` . so loader and error will be always undefined in props variable.