### PR TITLE
fix serialize object helper

### DIFF
--- a/packages/helpers/packages/ObjectHelpers/index.js
+++ b/packages/helpers/packages/ObjectHelpers/index.js
@@ -85,6 +85,9 @@ export const getNextProp = (object, key) => {
  * @returns {string}
  */
 export const serializeObject = object => {
+  if(!object || typeof object !== 'object'){
+    return '';
+  }
   const result = [];
   Object.keys(object).forEach(property => {
     if (typeof object[property] === 'object') {

--- a/packages/helpers/packages/ObjectHelpers/test/index.spec.js
+++ b/packages/helpers/packages/ObjectHelpers/test/index.spec.js
@@ -74,5 +74,8 @@ describe('ObjectHelpers', () => {
       const actual = '';
       expect(ObjectHelpers.serializeObject(payload)).toEqual(actual);
     });
+    it('should return return empty string cause payload is empty ', () => {
+      expect(ObjectHelpers.serializeObject(null)).toEqual('');
+    });
   });
 });


### PR DESCRIPTION
serialize object should handle invalid payload without throwing error,
so if the given payload was falsy or it wasn't an object, it should
return empty string