### PR TITLE
fix text wrap component

### DIFF
--- a/packages/ui/packages/TextWrap/src/index.js
+++ b/packages/ui/packages/TextWrap/src/index.js
@@ -1,28 +1,27 @@
 import * as React from 'react';
-import {useEffect, useRef, useState} from "react";
+import {useEffect, useRef} from "react";
 import PropTypes from 'prop-types';
 
 import { StyledTextWrap } from './styles';
 
 const TextWrap = ({ className, lines, children }) => {
-  const [height, setHeight] = useState(20);
   const textRef = useRef(null);
 
   useEffect(() => {
-    if(textRef.current){
-      const lineHeight = window.getComputedStyle(textRef.current).getPropertyValue('line-height');
-      setHeight(lines * (lineHeight ? parseInt(lineHeight, 10) : 0));
-    }
+    const lineHeight = window.getComputedStyle(textRef.current).getPropertyValue('line-height');
+    const height = lines * (lineHeight ? parseInt(lineHeight, 10) : 0);
+    textRef.current.style.height = `${height}px`;
   }, [textRef.current])
 
-  return <StyledTextWrap
-    ref={textRef}
-    data-testid="textWrap"
-    className={className}
-    height={height}
-  >
-    {children}
-  </StyledTextWrap>
+  return (
+    <StyledTextWrap
+      ref={textRef}
+      data-testid="textWrap"
+      className={className}
+    >
+      {children}
+    </StyledTextWrap>
+  )
 };
 
 TextWrap.propTypes = {

--- a/packages/ui/packages/TextWrap/src/styles.js
+++ b/packages/ui/packages/TextWrap/src/styles.js
@@ -5,7 +5,6 @@ const StyledTextWrap = Styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   position: relative;
-  height: ${props => props.height}px;
 `;
 
 export { StyledTextWrap };

--- a/packages/ui/packages/TextWrap/test/index.spec.js
+++ b/packages/ui/packages/TextWrap/test/index.spec.js
@@ -6,26 +6,42 @@ import { Wrapper } from '../../../test/test.helpers';
 import TextWrap from '../index';
 
 describe('TextWrap ui component tests', () => {
-  it('Should changes the style when get lines and lineHeight props', () => {
-    const { rerender, getByTestId } = render(
+  it('Should render content', () => {
+    const { getByTestId } = render(
       <Wrapper>
-        <TextWrap lines={2} lineHeight={2}>
-          textWrap content
+        <TextWrap lines={1}>
+          content
         </TextWrap>
       </Wrapper>,
     );
-
-    // expect(getByTestId('textWrap')).toHaveStyle({
-    //   height: 'calc(1rem * 2 * 2 )',
-    // });
-
-    rerender(
+    expect(getByTestId('textWrap')).toContainHTML('content');
+  });
+  it('Should change the height of the text wrap component show only one line', () => {
+    const originalGetComputedStyle = window.getComputedStyle;
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(() => ({
+      getPropertyValue: () => '20px'
+    }))
+    const { getByTestId } = render(
       <Wrapper>
-        <TextWrap lines={4} lineHeight={3}>
-          textWrap content
+        <TextWrap lines={2}>
+          content
         </TextWrap>
       </Wrapper>,
     );
-    expect(getByTestId('textWrap')).toContainHTML('textWrap content');
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(originalGetComputedStyle)
+
+    expect(getByTestId('textWrap')).toContainHTML('content');
+    expect(getByTestId('textWrap')).toHaveStyle('height: 40px;');
+  });
+
+  it('Should render with the className', () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <TextWrap className="foo" lines={1}>
+          content
+        </TextWrap>
+      </Wrapper>,
+    );
+    expect(getByTestId('textWrap')).toHaveClass('foo');
   });
 });


### PR DESCRIPTION
added test to text wrap component
remove height state from text wrap, since the height was set by the
state, it re-renders the component, besides since the height was only
affecting the style, and it causes recalculate style, user javascript to
set the height to reduce style calculation and re-render cause this
component is being used in many places in snappmarket